### PR TITLE
Fixes error when state column does not exists

### DIFF
--- a/lib/stator/machine.rb
+++ b/lib/stator/machine.rb
@@ -14,7 +14,7 @@ module Stator
       @field         = options[:field] || :state
       @namespace     = options[:namespace] || nil
 
-      @initial_state = klass.columns_hash[@field.to_s].default
+      @initial_state = klass.columns_hash[@field.to_s].try(:default)
 
       @transitions      = []
 
@@ -35,7 +35,7 @@ module Stator
     end
 
     def transition(name, &block)
-      
+
       t = ::Stator::Transition.new(@class_name, name, @namespace)
       t.instance_eval(&block) if block_given?
 
@@ -49,7 +49,7 @@ module Stator
     end
 
     def state(name, &block)
-      transition(nil) do 
+      transition(nil) do
         from any
         to name
         instance_eval(&block) if block_given?


### PR DESCRIPTION
Got an issue when deploying, the state column were added later but the code runs the AR model already, so there is an error:

undefined method 'default' for nil:NilClass
**\* xxx/gems/stator-0.0.7/lib/stator/machine.rb:17:in `initialize'

_sorry for whitespaces_
