### PR TITLE
Add scope/constant options to transition states

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'activerecord', '5.2.3'
 gemspec
 
 gem 'rake'
-gem 'activerecord-nulldb-adapter', '~> 0.4.0', :require => false, :git => 'git@github.com:nulldb/nulldb.git'
+gem 'activerecord-nulldb-adapter', '~> 0.4.0', :require => false, :git => 'https://github.com/nulldb/nulldb.git'
 gem 'rspec'

--- a/README.md
+++ b/README.md
@@ -206,7 +206,21 @@ state_alias :active, scope: :the_active_ones, constant: :the_active_states do
 end
 ```
 
-The `opposite` method also accepts the scope and constant options, but does not yield to a block since the state definitions are inheritenly tied to the ones described in the parent state_alias block.
+The `opposite` method also accepts the scope and constant options, as does the `to` method within a transition block, but they do not yield to a block since the state definitions are inheritenly tied to the ones described in the parent state_alias block/transition state:
+
+```ruby
+# will generate a User::INACTIVE_STATES constant, User.inactive scope, and User#inactive? instance method
+state_alias :active do
+  is :activated
+  opposite :inactive, scope: true, constant: true
+end
+
+# also works in a transition block
+transition :deactivate do
+  from :activated
+  to :inactive, scope: true, constant: true
+end
+```
 
 #### TODO
 

--- a/lib/stator/version.rb
+++ b/lib/stator/version.rb
@@ -4,7 +4,7 @@ module Stator
 
   MAJOR       = 0
   MINOR       = 3
-  PATCH       = 1
+  PATCH       = 2
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -277,9 +277,11 @@ describe Stator::Model do
 
       User::ACTIVE_STATES.should eql(%w[activated hyperactivated])
       User::INACTIVE_STATES.should eql(%w[pending deactivated semiactivated])
+      User::HYPERACTIVATED_STATE.should eq('hyperactivated')
 
       User.active.to_sql.gsub("  ", " ").should eq("SELECT users.* FROM users WHERE users.state IN ('activated', 'hyperactivated')")
       User.inactive.to_sql.gsub("  ", " ").should eq("SELECT users.* FROM users WHERE users.state IN ('pending', 'deactivated', 'semiactivated')")
+      User.hyperactivated.to_sql.gsub("  ", " ").should eq("SELECT users.* FROM users WHERE users.state = 'hyperactivated'")
     end
 
     it "should evaluate inverses correctly" do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -30,7 +30,7 @@ class User < ActiveRecord::Base
 
     transition :hyperactivate do
       from :activated
-      to :hyperactivated
+      to :hyperactivated, :scope => true, :constant => true
     end
 
     conditional :semiactivated, :activated do |condition|


### PR DESCRIPTION
Take an example state machine:
```ruby
# app/models/thing.rb
stator track: true, initial: "pending" do
  transition :activate do
    from :pending
    to :active
  end
end
```

Currently, if you want a scope to query for "active" records (`Thing.active`), you either have to create it separately or add a `state_alias`:
```ruby
state_alias :active, scope: true do
  is :active
end
```

...which seems excessive for the relatively simple case of adding a scope for a single state.

This PR proposes adding `scope` and `constant` options to `to` calls within transition blocks (similar to `opposite` calls within state_alias blocks) to provide a more concise way to add state scopes:
```ruby
transition :activate do
  from :pending
  to :active, scope: true, constant: true
end
```