### PR TITLE
Move without_state_* options to the integration instance for thread safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'activerecord', '5.2.3'
 
 gemspec
 
+gem 'activerecord-nulldb-adapter', '~> 0.4.0', require: false
 gem 'rake'
-gem 'activerecord-nulldb-adapter', '~> 0.4.0', :require => false, :git => 'git@github.com:nulldb/nulldb.git'
 gem 'rspec'

--- a/lib/stator/machine.rb
+++ b/lib/stator/machine.rb
@@ -7,16 +7,14 @@ module Stator
     attr_reader :transitions
     attr_reader :states
     attr_reader :namespace
-    attr_reader :skip_validations
-    attr_reader :skip_transition_tracking
-
 
     def initialize(klass, options = {})
-      @class_name    = klass.name
-      @field         = options[:field] || :state
-      @namespace     = options[:namespace] || nil
+      @class_name       = klass.name
+      @field            = options[:field] || :state
+      @namespace        = options[:namespace]
 
-      @initial_state = options[:initial] && options[:initial].to_s
+      @initial_state    = options[:initial] && options[:initial].to_s
+      @tracking_enabled = options[:track] || false
 
       @transitions      = []
       @aliases          = []
@@ -26,7 +24,6 @@ module Stator
       @states           = [@initial_state].compact
 
       @options       = options
-
     end
 
     def integration(record)
@@ -38,7 +35,6 @@ module Stator
     end
 
     def transition(name, &block)
-
       t = ::Stator::Transition.new(@class_name, name, @namespace)
       t.instance_eval(&block) if block_given?
 
@@ -66,6 +62,10 @@ module Stator
       end
     end
 
+    def tracking_enabled?
+      @tracking_enabled
+    end
+
     def conditional(*states, &block)
       _namespace = @namespace
 
@@ -86,22 +86,6 @@ module Stator
 
     def klass
       @class_name.constantize
-    end
-
-    def without_validation
-      was = @skip_validations
-      @skip_validations = true
-      yield
-    ensure
-      @skip_validations = was
-    end
-
-    def without_transition_tracking
-      was = @skip_transition_tracking
-      @skip_transition_tracking = true
-      yield
-    ensure
-      @skip_transition_tracking = was
     end
 
     protected

--- a/lib/stator/model.rb
+++ b/lib/stator/model.rb
@@ -99,10 +99,6 @@ module Stator
         @_integrations[namespace]
       end
 
-      def _integrations
-        @_integrations
-      end
-
     end
   end
 end

--- a/lib/stator/transition.rb
+++ b/lib/stator/transition.rb
@@ -86,7 +86,7 @@ module Stator
     def generate_methods
       klass.class_eval <<-EV, __FILE__, __LINE__ + 1
         def #{@full_name}(should_save = true)
-          integration = self._stator(#{@namespace.inspect}).integration(self)
+          integration = _integration(#{@namespace.to_s.inspect})
 
           unless can_#{@full_name}?
             integration.invalid_transition!(integration.state, #{@to.inspect}) if should_save
@@ -98,7 +98,7 @@ module Stator
         end
 
         def #{@full_name}!
-          integration = self._stator(#{@namespace.inspect}).integration(self)
+          integration = _integration(#{@namespace.to_s.inspect})
 
           unless can_#{@full_name}?
             integration.invalid_transition!(integration.state, #{@to.inspect})
@@ -110,10 +110,10 @@ module Stator
         end
 
         def can_#{@full_name}?
-          machine     = self._stator(#{@namespace.inspect})
-          return true if machine.skip_validations
+          integration = _integration(#{@namespace.to_s.inspect})
+          return true if integration.skip_validations
 
-          integration = machine.integration(self)
+          machine     = self._stator(#{@namespace.to_s.inspect})
           transition  = machine.transitions.detect{|t| t.full_name.to_s == #{@full_name.inspect}.to_s }
           transition.can?(integration.state)
         end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -166,10 +166,12 @@ describe Stator::Model do
     nope = User.new(email: "nope@example.com")
 
     threads << Thread.new do
+      sleep 0.5
       nope.semiactivate!
     end
     threads << Thread.new do
       skip.without_state_transition_tracking do
+        sleep 1
         skip.semiactivate!
       end
     end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -134,6 +134,33 @@ class Zoo < ActiveRecord::Base
   end
 end
 
+class ZooKeeper < ActiveRecord::Base
+  extend Stator::Model
+
+  stator namespace: 'employment', field: 'employment_state', track: true do
+    transition :hire do
+      from nil, :fired
+      to :hired
+    end
+
+    transition :fire do
+      from :hired
+      to :fired
+    end
+  end
+
+  stator namespace: 'working', field: 'working_state', track: false do
+    transition :start do
+      from nil, :ended
+      to :started
+    end
+
+    transition :end do
+      from :started
+      to :ended
+    end
+  end
+end
 
 class Farm < ActiveRecord::Base
   extend Stator::Model

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(:version => 20130628161227) do
     t.datetime "born_status_at"
   end
 
+  create_table "zoo_keepers", :force => true do |t|
+    t.string   "name"
+    t.string   "employment_state",                      :default => 'hired'
+    t.datetime "hired_employment_state_at"
+    t.datetime "fired_employment_state_at"
+    t.string   "working_state"
+    t.datetime "started_working_state_at"
+    t.datetime "ended_working_state_at"
+  end
+
   create_table "zoos", :force => true do |t|
     t.string   "name"
     t.string   "state",                                 :default => 'closed'


### PR DESCRIPTION
- Moves both without_state_* methods to the `integration` instance because the previous implementation was not thread safe.
- Also allow the `:track` option in the `stator` declaration to be configured per machine. Previously, if you were to have two namespaces, if any were `track: true`, both machines would track which doesn't seem intended.
- Integration instances are also now cached on the AR model itself per namespace so less instances are created.