### PR TITLE
Dont inherit _integration cache when duping a stator model instance

### DIFF
--- a/lib/stator/model.rb
+++ b/lib/stator/model.rb
@@ -69,6 +69,11 @@ module Stator
         end
       end
 
+      def initialize_dup(other)
+        @_integrations = {}
+        super
+      end
+
       def without_state_transition_validations(namespace = '')
         _integration(namespace).without_validation do
           yield self

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -181,6 +181,21 @@ describe Stator::Model do
     nope.semiactivated_state_at.should_not be_nil
     skip.semiactivated_state_at.should be_nil
   end
+
+  it "should not inherit _integration cache on dup" do
+    u = User.new(email: "user@example.com")
+    u.save!
+
+    u_duped = u.dup
+
+    u.semiactivate!
+
+    u_duped_integration = u_duped.send(:_integration)
+
+    u_duped_integration.state.should_not eql(u.state)
+    u_duped_integration.instance_values["record"].should eq(u_duped)
+  end
+
   describe "helper methods" do
     it "should answer the question of whether the state is currently the one invoked" do
       a = Animal.new


### PR DESCRIPTION
Noticed uses of `dup` was causing the @_integration cache to be duped over as well
This fixes the usage to clear the cache when `dup` is called