### PR TITLE
Add state_by?(state, time) and generated methods

### DIFF
--- a/lib/stator/integration.rb
+++ b/lib/stator/integration.rb
@@ -31,6 +31,14 @@ module Stator
       end
     end
 
+    def state_by?(state, time)
+      field_name = "#{state}_#{@machine.field}_at"
+      return false unless @record.respond_to?(field_name)
+      return false if @record.send(field_name).nil?
+      return true if time.nil?
+      @record.send(field_name) <= time
+    end
+
     def state_changed?(use_previous = false)
       if use_previous
         !!@record.previous_changes[@machine.field.to_s]

--- a/lib/stator/machine.rb
+++ b/lib/stator/machine.rb
@@ -117,6 +117,11 @@ module Stator
             integration = self._stator(#{@namespace.inspect}).integration(self)
             integration.state == #{state.to_s.inspect}
           end
+
+          def #{method_name}_by?(time)
+            integration = self._stator(#{@namespace.inspect}).integration(self)
+            integration.state_by?(#{state.to_s.inspect}, time)
+          end
         EV
       end
     end

--- a/lib/stator/model.rb
+++ b/lib/stator/model.rb
@@ -47,6 +47,10 @@ module Stator
         _integration(namespace).likely_state_at(t)
       end
 
+      def state_by?(state, t, namespace = '')
+        _integration(namespace).state_by?(state, t)
+      end
+
       protected
 
       def _stator_maybe_track_transition

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -305,6 +305,48 @@ describe Stator::Model do
       z.working_end!
       z.ended_working_state_at.should be_nil
     end
+
+    describe "#state_by?" do
+      it "should be true when the transition is earlier" do
+        t = Time.now
+        u = User.create!( email: "doug@example.com", activated_state_at: t)
+        u.state_by?(:activated, Time.at(t.to_i + 1)).should be true
+        u.activated_by?(Time.at(t.to_i + 1)).should be true
+      end
+
+      it "should be true when the transition is at the same time" do
+        t = Time.now
+        u = User.create!( email: "doug@example.com", activated_state_at: t)
+        u.state_by?(:activated, t).should be true
+        u.activated_by?(t).should be true
+      end
+
+      it "should be false when the transition is later" do
+        t = Time.now
+        u = User.create!( email: "doug@example.com", activated_state_at: t)
+        u.state_by?(:activated, Time.at(t.to_i - 1)).should be false
+        u.activated_by?(Time.at(t.to_i - 1)).should be false
+      end
+
+      it "should be false when the transition is nil" do
+        t = Time.now
+        u = User.create!( email: "doug@example.com", activated_state_at: nil)
+        u.state_by?(:activated, t).should be false
+        u.activated_by?(t).should be false
+      end
+
+      it "should be true when the transition is not nil and the time is nil" do
+        u = User.create!( email: "doug@example.com", activated_state_at: Time.now)
+        u.state_by?(:activated, nil).should be true
+        u.activated_by?(nil).should be true
+      end
+
+      it "should be false when both are nil" do
+        u = User.create!(email: "doug@example.com", activated_state_at: nil)
+        u.state_by?(:activated, nil).should be false
+        u.activated_by?(nil).should be false
+      end
+    end
   end
 
   describe "aliasing" do


### PR DESCRIPTION
Usually when you want to query a timestamp field, you basically want to ask it if the model was in e.g. the `activated` state by some time. Right now, you have to do this:
```ruby
if foo.activated_state_at && foo.activated_state_at < t
  ...
end
```

This PR adds the generic method `#state_by?(state, time)` and generated methods so that you can ask the question directly:

```ruby
if foo.activated_by?(t)
  ...
end
```