### PR TITLE
Generated methods for #state_by? are now _state_by? instead of just _by?

### DIFF
--- a/lib/stator/machine.rb
+++ b/lib/stator/machine.rb
@@ -118,7 +118,7 @@ module Stator
             integration.state == #{state.to_s.inspect}
           end
 
-          def #{method_name}_by?(time)
+          def #{method_name}_state_by?(time)
             integration = self._stator(#{@namespace.inspect}).integration(self)
             integration.state_by?(#{state.to_s.inspect}, time)
           end

--- a/lib/stator/version.rb
+++ b/lib/stator/version.rb
@@ -3,8 +3,8 @@
 module Stator
 
   MAJOR       = 0
-  MINOR       = 3
-  PATCH       = 4
+  MINOR       = 4
+  PATCH       = 0
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -311,40 +311,40 @@ describe Stator::Model do
         t = Time.now
         u = User.create!( email: "doug@example.com", activated_state_at: t)
         u.state_by?(:activated, Time.at(t.to_i + 1)).should be true
-        u.activated_by?(Time.at(t.to_i + 1)).should be true
+        u.activated_state_by?(Time.at(t.to_i + 1)).should be true
       end
 
       it "should be true when the transition is at the same time" do
         t = Time.now
         u = User.create!( email: "doug@example.com", activated_state_at: t)
         u.state_by?(:activated, t).should be true
-        u.activated_by?(t).should be true
+        u.activated_state_by?(t).should be true
       end
 
       it "should be false when the transition is later" do
         t = Time.now
         u = User.create!( email: "doug@example.com", activated_state_at: t)
         u.state_by?(:activated, Time.at(t.to_i - 1)).should be false
-        u.activated_by?(Time.at(t.to_i - 1)).should be false
+        u.activated_state_by?(Time.at(t.to_i - 1)).should be false
       end
 
       it "should be false when the transition is nil" do
         t = Time.now
         u = User.create!( email: "doug@example.com", activated_state_at: nil)
         u.state_by?(:activated, t).should be false
-        u.activated_by?(t).should be false
+        u.activated_state_by?(t).should be false
       end
 
       it "should be true when the transition is not nil and the time is nil" do
         u = User.create!( email: "doug@example.com", activated_state_at: Time.now)
         u.state_by?(:activated, nil).should be true
-        u.activated_by?(nil).should be true
+        u.activated_state_by?(nil).should be true
       end
 
       it "should be false when both are nil" do
         u = User.create!(email: "doug@example.com", activated_state_at: nil)
         u.state_by?(:activated, nil).should be false
-        u.activated_by?(nil).should be false
+        u.activated_state_by?(nil).should be false
       end
     end
   end


### PR DESCRIPTION
Matches the original intent and existing pattern. Prevents collisions
with stuff like recording which user canceled a record.