### PR TITLE
[NEXT] Includes fixes for AR::Dirty

### DIFF
--- a/lib/stator.rb
+++ b/lib/stator.rb
@@ -16,4 +16,8 @@ module Stator
   def self.default_namespace
     ENV.fetch('STATOR_NAMESPACE', :default).to_sym
   end
+
+  def self.satisfies_version?(vers)
+    ::Gem::Requirement.new(vers).satisfied_by?(::ActiveRecord.gem_version)
+  end
 end


### PR DESCRIPTION
This collects and brings in the fixes for Dirty/5.2+

NOTE: this is set to merge into `next-rails`, but should be reset to master when ready to go.